### PR TITLE
Fix submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "online-cv"]
-	path = online-cv
-	url = git:github.com/sergiovigo/online-cv.git
-
+    path = online-cv
+    url = https://github.com/sergiovigo/online-cv.git


### PR DESCRIPTION
## Summary
- fix `.gitmodules` with proper URL
- run `git submodule sync` and attempted `git submodule update --init` (failed due to network restrictions)

## Testing
- `git submodule sync`
- `git submodule update --init` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_685d72d07a1c832ab2e342016d4c4362