### PR TITLE
Fix submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "online-cv"]
 	path = online-cv
-	url = git:github.com/sergiovigo/online-cv.git
+	url = https://github.com/sergiovigo/online-cv.git
 


### PR DESCRIPTION
## Summary
- fix the `online-cv` submodule URL to use HTTPS

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle exec rake test` *(fails: rake not included)*

------
https://chatgpt.com/codex/tasks/task_e_685d6db5afd8832abbbcdc05af4ba8a7